### PR TITLE
feat(auth): Add dummy login endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.env
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+*.out
+.idea/
+.vscode/ 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,17 @@
+module avito-backend
+
+go 1.23.6
+
+require (
+	github.com/go-chi/chi/v5 v5.2.1
+	github.com/golang-jwt/jwt/v4 v4.5.2
+	github.com/joho/godotenv v1.5.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-chi/cors v1.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
+github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
 github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/go-chi/cors v1.2.1 h1:xEC8UT3Rlp2QuWNEr4Fs/c2EAGVKBwy/1vHx3bppil4=
+github.com/go-chi/cors v1.2.1/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
 github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/src/cmd/app/main.go
+++ b/src/cmd/app/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"avito-backend/src/internal/config"
+	"avito-backend/src/internal/delivery/http/handlers"
+	"avito-backend/src/internal/delivery/http/routes"
+	"avito-backend/src/internal/service"
+	"avito-backend/src/pkg/jwt"
+)
+
+func main() {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		log.Fatalf("Ошибка загрузки конфигурации: %v", err)
+	}
+
+	tokenManager := jwt.NewTokenManager(cfg.JWTSigningKey)
+	authService := service.NewAuthService(tokenManager)
+	authHandler := handlers.NewAuthHandler(authService)
+
+	router := routes.NewRouter(authHandler)
+
+	serverAddr := fmt.Sprintf(":%s", cfg.ServerPort)
+	log.Printf("Сервер запущен на порту %s", cfg.ServerPort)
+	if err := http.ListenAndServe(serverAddr, router.InitRoutes()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/src/cmd/app/main.go
+++ b/src/cmd/app/main.go
@@ -18,7 +18,7 @@ func main() {
 		log.Fatalf("Ошибка загрузки конфигурации: %v", err)
 	}
 
-	tokenManager := jwt.NewTokenManager(cfg.JWTSigningKey)
+	tokenManager := jwt.NewTokenManager(cfg.JWTSigningKey, cfg.JWTTokenDuration)
 	authService := service.NewAuthService(tokenManager)
 	authHandler := handlers.NewAuthHandler(authService)
 

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"os"
+
+	"github.com/joho/godotenv"
+)
+
+type Config struct {
+	ServerPort    string
+	JWTSigningKey string
+}
+
+func LoadConfig() (*Config, error) {
+	if err := godotenv.Load(); err != nil {
+		return nil, err
+	}
+
+	return &Config{
+		ServerPort:    getEnvVar("SERVER_PORT", "8080"),
+		JWTSigningKey: getEnvVar("JWT_SIGNING_KEY", "default-secret-key"),
+	}, nil
+}
+
+func getEnvVar(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}

--- a/src/internal/config/config.go
+++ b/src/internal/config/config.go
@@ -7,8 +7,9 @@ import (
 )
 
 type Config struct {
-	ServerPort    string
-	JWTSigningKey string
+	ServerPort       string
+	JWTSigningKey    string
+	JWTTokenDuration string
 }
 
 func LoadConfig() (*Config, error) {
@@ -17,8 +18,9 @@ func LoadConfig() (*Config, error) {
 	}
 
 	return &Config{
-		ServerPort:    getEnvVar("SERVER_PORT", "8080"),
-		JWTSigningKey: getEnvVar("JWT_SIGNING_KEY", "default-secret-key"),
+		ServerPort:       getEnvVar("SERVER_PORT", "8080"),
+		JWTSigningKey:    getEnvVar("JWT_SIGNING_KEY", "default-secret-key"),
+		JWTTokenDuration: getEnvVar("JWT_TOKEN_DURATION", "24h"),
 	}, nil
 }
 

--- a/src/internal/delivery/http/dto/request/auth.go
+++ b/src/internal/delivery/http/dto/request/auth.go
@@ -1,0 +1,5 @@
+package request
+
+type DummyLoginRequest struct {
+	Role string `json:"role"`
+}

--- a/src/internal/delivery/http/dto/response/error.go
+++ b/src/internal/delivery/http/dto/response/error.go
@@ -1,0 +1,5 @@
+package response
+
+type ErrorResponse struct {
+	Message string `json:"message"`
+}

--- a/src/internal/delivery/http/handlers/auth_handler.go
+++ b/src/internal/delivery/http/handlers/auth_handler.go
@@ -1,0 +1,51 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"avito-backend/src/internal/delivery/http/dto/request"
+	"avito-backend/src/internal/delivery/http/dto/response"
+	"avito-backend/src/internal/domain/models"
+	"avito-backend/src/internal/service"
+)
+
+type AuthHandler struct {
+	authService service.AuthServiceInterface
+}
+
+func NewAuthHandler(authService service.AuthServiceInterface) *AuthHandler {
+	return &AuthHandler{
+		authService: authService,
+	}
+}
+
+func (h *AuthHandler) DummyLogin(w http.ResponseWriter, r *http.Request) {
+	var req request.DummyLoginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.sendError(w, "Неверный формат запроса", http.StatusBadRequest)
+		return
+	}
+
+	if req.Role != string(models.EmployeeRole) && req.Role != string(models.ModeratorRole) {
+		h.sendError(w, "Недопустимая роль", http.StatusBadRequest)
+		return
+	}
+
+	token, err := h.authService.GenerateToken(req.Role)
+	if err != nil {
+		h.sendError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(token)
+}
+
+func (h *AuthHandler) sendError(w http.ResponseWriter, message string, code int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(response.ErrorResponse{
+		Message: message,
+	})
+}

--- a/src/internal/delivery/http/handlers/auth_handler_test.go
+++ b/src/internal/delivery/http/handlers/auth_handler_test.go
@@ -1,0 +1,99 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"avito-backend/src/internal/delivery/http/dto/request"
+	"avito-backend/src/internal/service/mocks"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthHandler_DummyLogin(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        request.DummyLoginRequest
+		mockBehavior func(s *mocks.AuthServiceMock, role string)
+		expectedCode int
+		expectedBody string
+	}{
+		{
+			name: "Success Employee",
+			input: request.DummyLoginRequest{
+				Role: "employee",
+			},
+			mockBehavior: func(s *mocks.AuthServiceMock, role string) {
+				s.On("GenerateToken", role).Return("test-token", nil)
+			},
+			expectedCode: http.StatusOK,
+			expectedBody: "\"test-token\"\n",
+		},
+		{
+			name: "Success Moderator",
+			input: request.DummyLoginRequest{
+				Role: "moderator",
+			},
+			mockBehavior: func(s *mocks.AuthServiceMock, role string) {
+				s.On("GenerateToken", role).Return("test-token", nil)
+			},
+			expectedCode: http.StatusOK,
+			expectedBody: "\"test-token\"\n",
+		},
+		{
+			name: "Invalid Role",
+			input: request.DummyLoginRequest{
+				Role: "invalid",
+			},
+			mockBehavior: func(s *mocks.AuthServiceMock, role string) {},
+			expectedCode: http.StatusBadRequest,
+			expectedBody: "{\"message\":\"Недопустимая роль\"}\n",
+		},
+		{
+			name: "Service Error",
+			input: request.DummyLoginRequest{
+				Role: "employee",
+			},
+			mockBehavior: func(s *mocks.AuthServiceMock, role string) {
+				s.On("GenerateToken", role).Return("", errors.New("service error"))
+			},
+			expectedCode: http.StatusInternalServerError,
+			expectedBody: "{\"message\":\"service error\"}\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockService := new(mocks.AuthServiceMock)
+			tt.mockBehavior(mockService, tt.input.Role)
+			handler := NewAuthHandler(mockService)
+
+			body, _ := json.Marshal(tt.input)
+			req := httptest.NewRequest("POST", "/dummyLogin", bytes.NewBuffer(body))
+			w := httptest.NewRecorder()
+
+			handler.DummyLogin(w, req)
+
+			assert.Equal(t, tt.expectedCode, w.Code)
+			assert.Equal(t, tt.expectedBody, w.Body.String())
+			mockService.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAuthHandler_DummyLogin_InvalidJSON(t *testing.T) {
+	mockService := new(mocks.AuthServiceMock)
+	handler := NewAuthHandler(mockService)
+
+	req := httptest.NewRequest("POST", "/dummyLogin", bytes.NewBuffer([]byte(`{"role": invalid_json`)))
+	w := httptest.NewRecorder()
+
+	handler.DummyLogin(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "{\"message\":\"Неверный формат запроса\"}\n", w.Body.String())
+}

--- a/src/internal/delivery/http/routes/routes.go
+++ b/src/internal/delivery/http/routes/routes.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/cors"
 )
 
 type Router struct {
@@ -20,14 +21,21 @@ func NewRouter(handler *handlers.AuthHandler) *Router {
 func (r *Router) InitRoutes() *chi.Mux {
 	router := chi.NewRouter()
 
+	router.Use(cors.Handler(cors.Options{
+		AllowedOrigins:   []string{"*"},
+		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type"},
+		ExposedHeaders:   []string{"Link"},
+		AllowCredentials: false,
+		MaxAge:           300,
+	}))
+
 	router.Use(middleware.Logger)
 	router.Use(middleware.Recoverer)
 	router.Use(middleware.RequestID)
 	router.Use(middleware.RealIP)
 
-	router.Group(func(router chi.Router) {
-		router.Post("/dummyLogin", r.handler.DummyLogin)
-	})
+	router.Post("/dummyLogin", r.handler.DummyLogin)
 
 	return router
 }

--- a/src/internal/delivery/http/routes/routes.go
+++ b/src/internal/delivery/http/routes/routes.go
@@ -1,0 +1,33 @@
+package routes
+
+import (
+	"avito-backend/src/internal/delivery/http/handlers"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+type Router struct {
+	handler *handlers.AuthHandler
+}
+
+func NewRouter(handler *handlers.AuthHandler) *Router {
+	return &Router{
+		handler: handler,
+	}
+}
+
+func (r *Router) InitRoutes() *chi.Mux {
+	router := chi.NewRouter()
+
+	router.Use(middleware.Logger)
+	router.Use(middleware.Recoverer)
+	router.Use(middleware.RequestID)
+	router.Use(middleware.RealIP)
+
+	router.Group(func(router chi.Router) {
+		router.Post("/dummyLogin", r.handler.DummyLogin)
+	})
+
+	return router
+}

--- a/src/internal/domain/models/user.go
+++ b/src/internal/domain/models/user.go
@@ -1,0 +1,12 @@
+package models
+
+type Role string
+
+const (
+	EmployeeRole  Role = "employee"
+	ModeratorRole Role = "moderator"
+)
+
+type User struct {
+	Role Role `json:"role"`
+}

--- a/src/internal/service/auth_service.go
+++ b/src/internal/service/auth_service.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"avito-backend/src/pkg/jwt"
+)
+
+type AuthServiceInterface interface {
+	GenerateToken(role string) (string, error)
+}
+
+type AuthService struct {
+	tokenManager *jwt.TokenManager
+}
+
+func NewAuthService(tokenManager *jwt.TokenManager) AuthServiceInterface {
+	return &AuthService{
+		tokenManager: tokenManager,
+	}
+}
+
+func (s *AuthService) GenerateToken(role string) (string, error) {
+	return s.tokenManager.GenerateToken(role)
+}

--- a/src/internal/service/auth_service_test.go
+++ b/src/internal/service/auth_service_test.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"testing"
+
+	"avito-backend/src/pkg/jwt"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthService_GenerateToken(t *testing.T) {
+	tokenManager := jwt.NewTokenManager("test-secret")
+	service := NewAuthService(tokenManager)
+
+	tests := []struct {
+		name    string
+		role    string
+		wantErr bool
+	}{
+		{
+			name:    "Success Employee",
+			role:    "employee",
+			wantErr: false,
+		},
+		{
+			name:    "Success Moderator",
+			role:    "moderator",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token, err := service.GenerateToken(tt.role)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Empty(t, token)
+			} else {
+				assert.NoError(t, err)
+				assert.NotEmpty(t, token)
+			}
+		})
+	}
+}

--- a/src/internal/service/auth_service_test.go
+++ b/src/internal/service/auth_service_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestAuthService_GenerateToken(t *testing.T) {
-	tokenManager := jwt.NewTokenManager("test-secret")
+	tokenManager := jwt.NewTokenManager("test-secret", "24h")
 	service := NewAuthService(tokenManager)
 
 	tests := []struct {

--- a/src/internal/service/mocks/auth_service_mock.go
+++ b/src/internal/service/mocks/auth_service_mock.go
@@ -1,0 +1,14 @@
+package mocks
+
+import (
+	"github.com/stretchr/testify/mock"
+)
+
+type AuthServiceMock struct {
+	mock.Mock
+}
+
+func (m *AuthServiceMock) GenerateToken(role string) (string, error) {
+	args := m.Called(role)
+	return args.String(0), args.Error(1)
+}

--- a/src/pkg/jwt/jwt.go
+++ b/src/pkg/jwt/jwt.go
@@ -13,17 +13,26 @@ type Claims struct {
 
 type TokenManager struct {
 	signingKey string
+	duration   string
 }
 
-func NewTokenManager(signingKey string) *TokenManager {
-	return &TokenManager{signingKey: signingKey}
+func NewTokenManager(signingKey string, duration string) *TokenManager {
+	return &TokenManager{
+		signingKey: signingKey,
+		duration:   duration,
+	}
 }
 
 func (m *TokenManager) GenerateToken(role string) (string, error) {
+	duration, err := time.ParseDuration(m.duration)
+	if err != nil {
+		return "", err
+	}
+
 	claims := Claims{
 		Role: role,
 		RegisteredClaims: jwt.RegisteredClaims{
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)),
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(duration)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
 		},
 	}

--- a/src/pkg/jwt/jwt.go
+++ b/src/pkg/jwt/jwt.go
@@ -1,0 +1,33 @@
+package jwt
+
+import (
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+)
+
+type Claims struct {
+	Role string `json:"role"`
+	jwt.RegisteredClaims
+}
+
+type TokenManager struct {
+	signingKey string
+}
+
+func NewTokenManager(signingKey string) *TokenManager {
+	return &TokenManager{signingKey: signingKey}
+}
+
+func (m *TokenManager) GenerateToken(role string) (string, error) {
+	claims := Claims{
+		Role: role,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString([]byte(m.signingKey))
+}

--- a/src/pkg/jwt/jwt_test.go
+++ b/src/pkg/jwt/jwt_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTokenManager_GenerateToken(t *testing.T) {
-	manager := NewTokenManager("test-secret")
+	manager := NewTokenManager("test-secret", "24h")
 
 	tests := []struct {
 		name    string

--- a/src/pkg/jwt/jwt_test.go
+++ b/src/pkg/jwt/jwt_test.go
@@ -1,0 +1,52 @@
+package jwt
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTokenManager_GenerateToken(t *testing.T) {
+	manager := NewTokenManager("test-secret")
+
+	tests := []struct {
+		name    string
+		role    string
+		wantErr bool
+	}{
+		{
+			name:    "Valid Token Generation",
+			role:    "employee",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token, err := manager.GenerateToken(tt.role)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Empty(t, token)
+			} else {
+				assert.NoError(t, err)
+
+				parsedToken, err := jwt.Parse(token, func(token *jwt.Token) (interface{}, error) {
+					return []byte("test-secret"), nil
+				})
+
+				assert.NoError(t, err)
+				assert.True(t, parsedToken.Valid)
+
+				claims, ok := parsedToken.Claims.(jwt.MapClaims)
+				assert.True(t, ok)
+				assert.Equal(t, tt.role, claims["role"])
+
+				exp := time.Unix(int64(claims["exp"].(float64)), 0)
+				assert.True(t, exp.After(time.Now()))
+			}
+		})
+	}
+}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -4,6 +4,10 @@ info:
   description: Сервис для управления ПВЗ и приемкой товаров
   version: 1.0.0
 
+servers:
+  - url: http://localhost:8080
+    description: Local development server
+
 components:
   schemas:
     Token:


### PR DESCRIPTION
- Добавлен эндпоинт для тестовой авторизации

- Написаны unit тесты для основных состовляющих:
1. Успешная генерация токена для сотрудника
2. Успешная генерация токена для модератора
3. Обработка некорректной роли
4. Обработка ошибок сервиса
5. Обработка некорректного JSON в запросе
6. Валидация сгенерированного JWT токена

- Немного изменена спецификация Swagger для локального тестирования сервера